### PR TITLE
Add child theme support

### DIFF
--- a/layouts/config/stylesheet_header.erb
+++ b/layouts/config/stylesheet_header.erb
@@ -5,6 +5,9 @@
  * Author URI: <%= config["author_uri"] %>
  * Description: <%= config["description"] if config["description"] %>
  * Version: <%= config["version_number"] if config["version_number"] %>
+<% if config["template"] -%>
+ * Template: <%= config["template"] %>
+<% end -%>
  * License: <%= config["license_name"] if config["license_name"] %>
  * License URI: <%= config["license_uri"] if config["license_uri"] %>
  * Tags: <%= config["tags"].join(", ") if config["tags"] %>


### PR DESCRIPTION
A small addition to stylesheet header generation… I've added the possibility to specify the `template` property in config.json, which is of course compiled into `Template:` in the resulting `style.css`. This enables development of child themes using Forge.
