### PR TITLE
Add config['preserve_template_struct'] option. Off by default.

### DIFF
--- a/layouts/config/config.json.erb
+++ b/layouts/config/config.json.erb
@@ -32,5 +32,8 @@
   "comments": "<%= config[:comments] %>",
 
   // Enable livereload gem
-  "live_reload": false
+  "live_reload": false,
+
+  // Preserve the directory structure of files under source/templates
+  "preserve_template_struct": false
 }


### PR DESCRIPTION
Add a "preserve_template_struct" option to config.json and honor the setting in builder.rd

As in issue #28
