### PR TITLE
Place meta charset tag at beginning of head, above title, for compatibility

### DIFF
--- a/layouts/default/templates/header.php.erb
+++ b/layouts/default/templates/header.php.erb
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html <?php language_attributes( 'html' ) ?>>
 <head>
 	<meta charset="<?php bloginfo( 'charset' ); ?>" />


### PR DESCRIPTION
According to [Google Doctype on the meta charset declaration](http://code.google.com/p/doctype-mirror/wiki/MetaCharsetAttribute),

> In order for all browsers to recognize a &lt;meta charset&gt; declaration, it must be
> - Within the &lt;head&gt; element,
> - Before any elements that contain text, such as the &lt;title&gt; element, AND
> - Within the first 512 bytes of your document, including DOCTYPE and whitespace.

This patch simply places the &lt;meta charset&gt; tag above the &lt;title&gt; tag, instead of below it, in documents generated by forge.
