### PR TITLE
Append extra paths from config

### DIFF
--- a/lib/forge/builder.rb
+++ b/lib/forge/builder.rb
@@ -219,6 +219,12 @@ module Forge
         @sprockets.append_path File.join(@assets_path, dir)
       end
 
+      if @project.config[:sprockets_paths]
+        @project.config[:sprockets_paths].each do |dir|
+          @sprockets.append_path dir
+        end
+      end
+
       # Add assets/styleshets to load path for Less Engine
       Tilt::LessTemplateWithPaths.load_path = File.join(@assets_path, 'stylesheets')
 


### PR DESCRIPTION
Added a simple way to extend sprockets' load paths from config.rb.
